### PR TITLE
Fix update script for ppc64le

### DIFF
--- a/register/register.sh
+++ b/register/register.sh
@@ -43,7 +43,7 @@ case "$cpu" in
     mips*)
         cpu="mips"
         ;;
-    "Power Macintosh"|ppc|ppc64)
+    "Power Macintosh"|ppc|ppc64*)
         cpu="ppc"
         ;;
     armv[4-9]*)


### PR DESCRIPTION
If you want to run this on a ppc64le system you'll need this.

Note: You'll also (for time being) need to update the FROM line
to ppc64le/busybox.

Signed-off-by: Christy Perez <christy@linux.vnet.ibm.com>