### PR TITLE
travis: refactor into URI and package filename

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,15 @@ env:
     global:
         - VERSION=2.9.1
         - REPO=multiarch/qemu-user-static
+        - PACKAGE_URI="https://kojipkgs.fedoraproject.org/packages/qemu/2.9.1/2.fc26/x86_64/qemu-user-static-2.9.1-2.fc26.x86_64.rpm"
+        - PACKAGE_FILENAME=qemu-user-static-2.9.1-2.fc26.x86_64.rpm
 branches:
   only:
     - master
 before_script:
     - sudo apt-get install jq rpm2cpio cpio
-    - wget --content-disposition https://kojipkgs.fedoraproject.org/packages/qemu/2.9.0/1.fc27/x86_64/qemu-user-static-2.9.0-1.fc27.x86_64.rpm
-    - sudo rpm2cpio qemu-user-static-2.9.0-1.fc27.x86_64.rpm | cpio -dimv
+    - wget --content-disposition $PACKAGE_URI
+    - sudo rpm2cpio $PACKAGE_FILENAME | cpio -dimv
 script:
     - sudo ./publish.sh -v "$VERSION" -t "$GITHUB_TOKEN" -r "$REPO"
     - sudo ./update.sh -v "$VERSION" -r "$REPO"


### PR DESCRIPTION
Version was set to 2.9.1 but the package URI was still pinned to 2.9.0

* Fixes #30