### PR TITLE
Add new targets to --reset list

### DIFF
--- a/register/register.sh
+++ b/register/register.sh
@@ -14,7 +14,7 @@ if [ ! -f /proc/sys/fs/binfmt_misc/register ]; then
     mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc
 fi
 
-entries="aarch64 alpha arm armeb hppa m68k mips mips64 mips64el mipsel mipsn32 mipsn32el ppc ppc64 ppc64le s390x sh4 sh4eb sparc sparc32plus sparc64"
+entries="aarch64 aarch64_be alpha arm armeb hppa m68k microblaze microblazeel mips mips64 mips64el mipsel mipsn32 mipsn32el ppc ppc64 ppc64le riscv32 riscv64 s390x sh4 sh4eb sparc sparc32plus sparc64 xtensa xtensaeb"
 
 if [ "${1}" = "--reset" ]; then
     shift


### PR DESCRIPTION
6a9c52b5456fc9325f5de4602d250607890af956 added several new targets, but they weren't added to the list of targets to `--reset`, and so now running `docker run --rm --privileged multiarch/qemu-user-static:register --reset` multiple times on the same host fails:
```console
$ docker run --rm --privileged multiarch/qemu-user-static:register --reset
Setting /usr/bin/qemu-alpha-static as binfmt interpreter for alpha
Setting /usr/bin/qemu-arm-static as binfmt interpreter for arm
Setting /usr/bin/qemu-armeb-static as binfmt interpreter for armeb
Setting /usr/bin/qemu-sparc32plus-static as binfmt interpreter for sparc32plus
Setting /usr/bin/qemu-ppc-static as binfmt interpreter for ppc
Setting /usr/bin/qemu-ppc64-static as binfmt interpreter for ppc64
Setting /usr/bin/qemu-ppc64le-static as binfmt interpreter for ppc64le
Setting /usr/bin/qemu-m68k-static as binfmt interpreter for m68k
Setting /usr/bin/qemu-mips-static as binfmt interpreter for mips
Setting /usr/bin/qemu-mipsel-static as binfmt interpreter for mipsel
Setting /usr/bin/qemu-mipsn32-static as binfmt interpreter for mipsn32
Setting /usr/bin/qemu-mipsn32el-static as binfmt interpreter for mipsn32el
Setting /usr/bin/qemu-mips64-static as binfmt interpreter for mips64
Setting /usr/bin/qemu-mips64el-static as binfmt interpreter for mips64el
Setting /usr/bin/qemu-sh4-static as binfmt interpreter for sh4
Setting /usr/bin/qemu-sh4eb-static as binfmt interpreter for sh4eb
Setting /usr/bin/qemu-s390x-static as binfmt interpreter for s390x
Setting /usr/bin/qemu-aarch64-static as binfmt interpreter for aarch64
Setting /usr/bin/qemu-aarch64_be-static as binfmt interpreter for aarch64_be
sh: write error: File exists
Setting /usr/bin/qemu-hppa-static as binfmt interpreter for hppa
sh: write error: File exists
Setting /usr/bin/qemu-riscv32-static as binfmt interpreter for riscv32
Setting /usr/bin/qemu-riscv64-static as binfmt interpreter for riscv64
sh: write error: File exists
Setting /usr/bin/qemu-xtensa-static as binfmt interpreter for xtensa
sh: write error: File exists
sh: write error: File exists
Setting /usr/bin/qemu-xtensaeb-static as binfmt interpreter for xtensaeb
Setting /usr/bin/qemu-microblaze-static as binfmt interpreter for microblaze
sh: write error: File exists
sh: write error: File exists
Setting /usr/bin/qemu-microblazeel-static as binfmt interpreter for microblazeel
```

This PR adds these new missing targets to the list in `register.sh`, though I wonder if a better fix is to just unregister everything matching `/proc/sys/fs/binfmt_misc/status/qemu-*`.
