### PR TITLE
Pipe dockerfile, deprecate 'sudo' in .travis.yml, allow to test feature branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: required
 services: docker
 language: bash
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ before_script:
     - wget --content-disposition $PACKAGE_URI
     - rpm2cpio $PACKAGE_FILENAME | cpio -dimv
 script:
-    - ./publish.sh -v "$VERSION" -t "$GITHUB_TOKEN" -r "$REPO"
+    - ./generate_tarballs.sh
+    - if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then ./publish.sh -v "$VERSION" -t "$GITHUB_TOKEN" -r "$REPO"; fi
     - ./update.sh -v "$VERSION" -r "$REPO"
 after_success:
     - if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" && docker push $REPO; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ env:
 before_script:
     - sudo apt-get install jq rpm2cpio cpio
     - wget --content-disposition $PACKAGE_URI
-    - sudo rpm2cpio $PACKAGE_FILENAME | cpio -dimv
+    - rpm2cpio $PACKAGE_FILENAME | cpio -dimv
 script:
-    - sudo ./publish.sh -v "$VERSION" -t "$GITHUB_TOKEN" -r "$REPO"
-    - sudo ./update.sh -v "$VERSION" -r "$REPO"
+    - ./publish.sh -v "$VERSION" -t "$GITHUB_TOKEN" -r "$REPO"
+    - ./update.sh -v "$VERSION" -r "$REPO"
 after_success:
     - if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" && docker push $REPO; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,15 @@ env:
         - REPO=multiarch/qemu-user-static
         - PACKAGE_URI="https://kojipkgs.fedoraproject.org/packages/qemu/3.1.0/2.fc30/x86_64/qemu-user-static-3.1.0-2.fc30.x86_64.rpm"
         - PACKAGE_FILENAME=qemu-user-static-3.1.0-2.fc30.x86_64.rpm
-branches:
-  only:
-    - master
+#branches:
+#  only:
+#    - master
 before_script:
     - sudo apt-get install jq rpm2cpio cpio
     - wget --content-disposition $PACKAGE_URI
     - sudo rpm2cpio $PACKAGE_FILENAME | cpio -dimv
 script:
-    - if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then sudo ./publish.sh -v "$VERSION" -t "$GITHUB_TOKEN" -r "$REPO"; fi
-    - if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then sudo ./update.sh -v "$VERSION" -r "$REPO"; fi
+    - sudo ./publish.sh -v "$VERSION" -t "$GITHUB_TOKEN" -r "$REPO"
+    - sudo ./update.sh -v "$VERSION" -r "$REPO"
 after_success:
     - if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" && docker push $REPO; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ env:
         - REPO=multiarch/qemu-user-static
         - PACKAGE_URI="https://kojipkgs.fedoraproject.org/packages/qemu/3.1.0/2.fc30/x86_64/qemu-user-static-3.1.0-2.fc30.x86_64.rpm"
         - PACKAGE_FILENAME=qemu-user-static-3.1.0-2.fc30.x86_64.rpm
-#branches:
-#  only:
-#    - master
 before_script:
     - sudo apt-get install jq rpm2cpio cpio
     - wget --content-disposition $PACKAGE_URI

--- a/generate_tarballs.sh
+++ b/generate_tarballs.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+
+rm -rf releases
+mkdir -p releases
+# find . -regex './qemu-.*' -not -regex './qemu-system-.*' -exec cp {} releases \;
+cp ./usr/bin/qemu-*-static releases/
+cd releases/
+for file in *; do
+    tar -czf $file.tar.gz $file;
+    cp $file.tar.gz x86_64_$file.tar.gz
+done

--- a/publish.sh
+++ b/publish.sh
@@ -28,34 +28,38 @@ for file in *; do
     cp $file.tar.gz x86_64_$file.tar.gz
 done
 
-# create a release
-release_id=$(curl -sL -X POST \
-    -H "Content-Type: application/json" \
-    -H "Accept: application/vnd.github.v3+json" \
-    -H "Authorization: token ${GITHUB_TOKEN}" \
-    -H "Cache-Control: no-cache" -d "{
-  \"tag_name\": \"v${VERSION}\",
-  \"target_commitish\": \"master\",
-  \"name\": \"v${VERSION}\",
-  \"body\": \"# \`qemu-*-static\` @ ${VERSION}\",
-  \"draft\": false,
-  \"prerelease\": false
-}" "https://api.github.com/repos/${REPO}/releases" | jq -r ".id")
-if [ "$release_id" = "null" ]; then
-    # get the existing release id
-    release_id=$(set -x; curl -sL \
-    -H "Content-Type: application/json" \
-    -H "Accept: application/vnd.github.v3+json" \
-    -H "Authorization: token ${GITHUB_TOKEN}" \
-    -H "Cache-Control: no-cache" \
-    "https://api.github.com/repos/${REPO}/releases" | jq -r --arg version "${VERSION}" '.[] | select(.name == "v"+$version).id')
-fi
+if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then
 
-for file in *; do
-    content_type=$(file --mime-type -b ${file})
-    curl -sL \
-        -H "Authorization: token ${GITHUB_TOKEN}" \
-        -H "Content-Type: ${content_type}" \
-        --upload-file ${file} \
-        "https://uploads.github.com/repos/${REPO}/releases/${release_id}/assets?name=${file}"
-done
+  # create a release
+  release_id=$(curl -sL -X POST \
+      -H "Content-Type: application/json" \
+      -H "Accept: application/vnd.github.v3+json" \
+      -H "Authorization: token ${GITHUB_TOKEN}" \
+      -H "Cache-Control: no-cache" -d "{
+    \"tag_name\": \"v${VERSION}\",
+    \"target_commitish\": \"master\",
+    \"name\": \"v${VERSION}\",
+    \"body\": \"# \`qemu-*-static\` @ ${VERSION}\",
+    \"draft\": false,
+    \"prerelease\": false
+  }" "https://api.github.com/repos/${REPO}/releases" | jq -r ".id")
+  if [ "$release_id" = "null" ]; then
+      # get the existing release id
+      release_id=$(set -x; curl -sL \
+      -H "Content-Type: application/json" \
+      -H "Accept: application/vnd.github.v3+json" \
+      -H "Authorization: token ${GITHUB_TOKEN}" \
+      -H "Cache-Control: no-cache" \
+      "https://api.github.com/repos/${REPO}/releases" | jq -r --arg version "${VERSION}" '.[] | select(.name == "v"+$version).id')
+  fi
+
+  for file in *; do
+      content_type=$(file --mime-type -b ${file})
+      curl -sL \
+          -H "Authorization: token ${GITHUB_TOKEN}" \
+          -H "Content-Type: ${content_type}" \
+          --upload-file ${file} \
+          "https://uploads.github.com/repos/${REPO}/releases/${release_id}/assets?name=${file}"
+  done
+
+fi

--- a/publish.sh
+++ b/publish.sh
@@ -18,48 +18,34 @@ shift $((OPTIND-1))
 
 [ "$1" = "--" ] && shift
 
-rm -rf releases
-mkdir -p releases
-# find . -regex './qemu-.*' -not -regex './qemu-system-.*' -exec cp {} releases \;
-cp ./usr/bin/qemu-*-static releases/
-cd releases/
-for file in *; do
-    tar -czf $file.tar.gz $file;
-    cp $file.tar.gz x86_64_$file.tar.gz
-done
-
-if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then
-
-  # create a release
-  release_id=$(curl -sL -X POST \
-      -H "Content-Type: application/json" \
-      -H "Accept: application/vnd.github.v3+json" \
-      -H "Authorization: token ${GITHUB_TOKEN}" \
-      -H "Cache-Control: no-cache" -d "{
-    \"tag_name\": \"v${VERSION}\",
-    \"target_commitish\": \"master\",
-    \"name\": \"v${VERSION}\",
-    \"body\": \"# \`qemu-*-static\` @ ${VERSION}\",
-    \"draft\": false,
-    \"prerelease\": false
-  }" "https://api.github.com/repos/${REPO}/releases" | jq -r ".id")
-  if [ "$release_id" = "null" ]; then
-      # get the existing release id
-      release_id=$(set -x; curl -sL \
-      -H "Content-Type: application/json" \
-      -H "Accept: application/vnd.github.v3+json" \
-      -H "Authorization: token ${GITHUB_TOKEN}" \
-      -H "Cache-Control: no-cache" \
-      "https://api.github.com/repos/${REPO}/releases" | jq -r --arg version "${VERSION}" '.[] | select(.name == "v"+$version).id')
-  fi
-
-  for file in *; do
-      content_type=$(file --mime-type -b ${file})
-      curl -sL \
-          -H "Authorization: token ${GITHUB_TOKEN}" \
-          -H "Content-Type: ${content_type}" \
-          --upload-file ${file} \
-          "https://uploads.github.com/repos/${REPO}/releases/${release_id}/assets?name=${file}"
-  done
-
+# create a release
+release_id=$(curl -sL -X POST \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/vnd.github.v3+json" \
+    -H "Authorization: token ${GITHUB_TOKEN}" \
+    -H "Cache-Control: no-cache" -d "{
+  \"tag_name\": \"v${VERSION}\",
+  \"target_commitish\": \"master\",
+  \"name\": \"v${VERSION}\",
+  \"body\": \"# \`qemu-*-static\` @ ${VERSION}\",
+  \"draft\": false,
+  \"prerelease\": false
+}" "https://api.github.com/repos/${REPO}/releases" | jq -r ".id")
+if [ "$release_id" = "null" ]; then
+    # get the existing release id
+    release_id=$(set -x; curl -sL \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/vnd.github.v3+json" \
+    -H "Authorization: token ${GITHUB_TOKEN}" \
+    -H "Cache-Control: no-cache" \
+    "https://api.github.com/repos/${REPO}/releases" | jq -r --arg version "${VERSION}" '.[] | select(.name == "v"+$version).id')
 fi
+
+for file in *; do
+    content_type=$(file --mime-type -b ${file})
+    curl -sL \
+        -H "Authorization: token ${GITHUB_TOKEN}" \
+        -H "Content-Type: ${content_type}" \
+        --upload-file ${file} \
+        "https://uploads.github.com/repos/${REPO}/releases/${release_id}/assets?name=${file}"
+done

--- a/update.sh
+++ b/update.sh
@@ -28,12 +28,10 @@ to_archs=("aarch64" "alpha" "arm" "armeb" "cris" "hppa" "i386" "m68k" "microblaz
 
 for to_arch in "${to_archs[@]}"; do
     if [ "$from_arch" != "$to_arch" ]; then
-        mkdir -p archs/$from_arch-$to_arch
-        cat > archs/$from_arch-$to_arch/Dockerfile <<EOF
+        docker build -t ${REPO}:$from_arch-$to_arch -<<EOF
 FROM scratch
 ADD https://github.com/${REPO}/releases/download/v${VERSION}/${from_arch}_qemu-${to_arch}-static.tar.gz /usr/bin
 EOF
-        docker build -t ${REPO}:$from_arch-$to_arch archs/$from_arch-$to_arch
         docker tag ${REPO}:$from_arch-$to_arch ${REPO}:$to_arch
     fi
 done


### PR DESCRIPTION
This PR includes three minor changes:

- Some conditions are moved in order to allow testing feature branches (not master) on Travis.
- Instead of creating a Dockerfile for each image, the content is piped through stdin as explained at [Pipe Dockerfile through stdin](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#pipe-dockerfile-through-stdin).
- Key `sudo` is deprecated now: [blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).