### PR TITLE
style: bash array is not required

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -24,9 +24,9 @@ shift $((OPTIND-1))
 [ "$1" = "--" ] && shift
 
 from_arch="x86_64"
-to_archs=("aarch64" "alpha" "arm" "armeb" "cris" "hppa" "i386" "m68k" "microblaze" "microblazeel" "mips" "mips64" "mips64el" "mipsel" "mipsn32" "mipsn32el" "nios2" "or1k" "ppc" "ppc64" "ppc64abi32" "ppc64le" "s390x" "sh4" "sh4eb" "sparc" "sparc32plus" "sparc64" "x86_64")
+to_archs="aarch64 alpha arm armeb cris hppa i386 m68k microblaze microblazeel mips mips64 mips64el mipsel mipsn32 mipsn32el nios2 or1k ppc ppc64 ppc64abi32 ppc64le s390x sh4 sh4eb sparc sparc32plus sparc64 x86_64"
 
-for to_arch in "${to_archs[@]}"; do
+for to_arch in $to_archs; do
     if [ "$from_arch" != "$to_arch" ]; then
         docker build -t ${REPO}:$from_arch-$to_arch -<<EOF
 FROM scratch


### PR DESCRIPTION
This PR includes two commits. The first one is the same as in #54. The other one, specific to this issue, is the change in `update.sh` to improve portability. See https://unix.stackexchange.com/questions/384614/how-to-port-to-bash-style-arrays-to-ash.