### PR TITLE
 feat: extract only the desired content from the rpm package 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,7 @@ env:
         - VERSION=3.1.0-2
         - REPO=multiarch/qemu-user-static
         - PACKAGE_URI="https://kojipkgs.fedoraproject.org/packages/qemu/3.1.0/2.fc30/x86_64/qemu-user-static-3.1.0-2.fc30.x86_64.rpm"
-        - PACKAGE_FILENAME=qemu-user-static-3.1.0-2.fc30.x86_64.rpm
-before_script:
-    - sudo apt-get install jq rpm2cpio cpio
-    - wget --content-disposition $PACKAGE_URI
-    - rpm2cpio $PACKAGE_FILENAME | cpio -dimv
+before_script: sudo apt-get install jq rpm2cpio cpio
 script:
     - ./generate_tarballs.sh
     - if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then ./publish.sh -v "$VERSION" -t "$GITHUB_TOKEN" -r "$REPO"; fi

--- a/generate_tarballs.sh
+++ b/generate_tarballs.sh
@@ -2,9 +2,13 @@
 
 rm -rf releases
 mkdir -p releases
-# find . -regex './qemu-.*' -not -regex './qemu-system-.*' -exec cp {} releases \;
-cp ./usr/bin/qemu-*-static releases/
-cd releases/
+
+cd releases
+
+curl -fsSL "$PACKAGE_URI" | rpm2cpio - | cpio -dimv "*usr/bin*qemu-*-static"
+mv ./usr/bin/* ./
+rm -rf ./usr/bin
+
 for file in *; do
     tar -czf $file.tar.gz $file;
     cp $file.tar.gz x86_64_$file.tar.gz


### PR DESCRIPTION
This PR includes two commits. The first one is the same as in #54, #55 and #57. The other one, specific to this issue, is replacing the following commands in `before_script`:

``` bash
    - wget --content-disposition $PACKAGE_URI
    - sudo rpm2cpio $PACKAGE_FILENAME | cpio -dimv
```

with these in `publish.sh`:

``` bash
curl -fsSL "$PACKAGE_URI" | rpm2cpio - | cpio -dimv "*usr/bin*qemu-*-static"
mv ./usr/bin/* ./
rm -rf ./usr/bin
```

Note that the extraction with `cpio` is filtered so that only the desired binaries are saved to the local dir. Moreover, since the output from curl is piped to rpm2cpio, the full package is not written to disk.