### PR TITLE
use gpg to avoid insecure docker login warning (travis-ci/travis-ci#9495)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 services: docker
 language: bash
+addons:
+  apt:
+    packages:
+      - pass
 env:
     global:
         - VERSION=3.1.0-2
@@ -15,4 +19,4 @@ script:
     - if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then ./publish.sh -v "$VERSION" -t "$GITHUB_TOKEN" -r "$REPO"; fi
     - ./update.sh -v "$VERSION" -r "$REPO"
 after_success:
-    - if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" && docker push $REPO; fi
+    - if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then ./deploy.sh; fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,45 @@
+#!/bin/bash -e
+
+cd "$(dirname $0)"
+
+#--
+
+getDockerCredentialPass () {
+  PASS_URL="$(curl -s https://api.github.com/repos/docker/docker-credential-helpers/releases/latest \
+    | grep "browser_download_url.*pass-.*-amd64" \
+    | cut -d : -f 2,3 \
+    | tr -d \" \
+    | cut -c2- )"
+
+  [ "$(echo "$PASS_URL" | cut -c1-5)" != "https" ] && PASS_URL="https://github.com/docker/docker-credential-helpers/releases/download/v0.6.0/docker-credential-pass-v0.6.0-amd64.tar.gz"
+
+  echo "PASS_URL: $PASS_URL"
+  curl -fsSL "$PASS_URL" | tar xv
+  chmod + $(pwd)/docker-credential-pass
+}
+
+#--
+
+dockerLogin () {
+  [ "$CI" = "true" ] && gpg --batch --gen-key <<-EOF ; pass init $(gpg --no-auto-check-trustdb --list-secret-keys | grep ^sec | cut -d/ -f2 | cut -d" " -f1)
+%echo Generating a standard key
+Key-Type: DSA
+Key-Length: 1024
+Subkey-Type: ELG-E
+Subkey-Length: 1024
+Name-Real: Meshuggah Rocks
+Name-Email: meshuggah@example.com
+Expire-Date: 0
+# Do a commit here, so that we can later print "done" :-)
+%commit
+%echo done
+EOF
+  echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+}
+
+#--
+
+getDockerCredentialPass
+dockerLogin
+docker push $REPO
+docker logout


### PR DESCRIPTION
Now, a warning is shown because `docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"` is used. See https://travis-ci.org/multiarch/qemu-user-static/builds/498405438#L1749

If it was changed to `echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin`, that warning would be replaced with `WARNING! Your password will be stored unencrypted in /home/travis/.docker/config.json.`. A straightforward solution, as explained in travis-ci/travis-ci#9495, is to use `docker-credential-pass` and GPG. This PR implements this approach.

Note that the latest release of `docker-credential-pass` is retrieved through GitHub API, so it is not required to keep updating it. However, a fallback default is provided, in case GitHub API fails.