### PR TITLE
[feat] Upgrade qemu to v4.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,33 +2,33 @@ dist: xenial
 services: docker
 language: bash
 addons:
-    apt:
-        config:
-            retries: true
-        update: true
-        packages:
-            - jq
-            - rpm2cpio
-            - cpio
+  apt:
+    config:
+      retries: true
+    update: true
+    packages:
+      - jq
+      - rpm2cpio
+      - cpio
 env:
-    global:
-        - VERSION=3.1.0-3
-        - REPO=multiarch/qemu-user-static
-        - PACKAGE_URI="https://kojipkgs.fedoraproject.org/packages/qemu/3.1.0/6.fc30/x86_64/qemu-user-static-3.1.0-6.fc30.x86_64.rpm"
-        - PACKAGE_FILENAME=$(basename "$PACKAGE_URI")
+  global:
+    - VERSION=4.0.0
+    - REPO=jessestuart/qemu-user-static
+    - PACKAGE_URI="https://kojipkgs.fedoraproject.org/packages/qemu/4.0.0/1.fc31/x86_64/qemu-user-static-4.0.0-1.fc31.x86_64.rpm"
+    - PACKAGE_FILENAME=$(basename "$PACKAGE_URI")
 before_script:
-    - wget --content-disposition $PACKAGE_URI
-    - rpm2cpio $PACKAGE_FILENAME | cpio -dimv
+  - wget --content-disposition $PACKAGE_URI
+  - rpm2cpio $PACKAGE_FILENAME | cpio -dimv
 script:
-    - ./generate_tarballs.sh
-    - |
-      if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then
-          ./publish.sh -v "$VERSION" -t "$GITHUB_TOKEN" -r "$REPO" && \
-              ./update.sh -v "$VERSION" -r "$REPO"
-      fi
+  - ./generate_tarballs.sh
+  - |
+    if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then
+        ./publish.sh -v "$VERSION" -t "$GITHUB_TOKEN" -r "$REPO" && \
+            ./update.sh -v "$VERSION" -r "$REPO"
+    fi
 after_success:
-    - |
-      if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then
-          docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" && \
-              docker push $REPO
-      fi
+  - |
+    if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then
+        docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" && \
+            docker push $REPO
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,33 +2,33 @@ dist: xenial
 services: docker
 language: bash
 addons:
-  apt:
-    config:
-      retries: true
-    update: true
-    packages:
-      - jq
-      - rpm2cpio
-      - cpio
+    apt:
+        config:
+            retries: true
+        update: true
+        packages:
+            - jq
+            - rpm2cpio
+            - cpio
 env:
-  global:
-    - VERSION=4.0.0
-    - REPO=jessestuart/qemu-user-static
-    - PACKAGE_URI="https://kojipkgs.fedoraproject.org/packages/qemu/4.0.0/1.fc31/x86_64/qemu-user-static-4.0.0-1.fc31.x86_64.rpm"
-    - PACKAGE_FILENAME=$(basename "$PACKAGE_URI")
+    global:
+        - VERSION=4.0.0
+        - REPO=multiarch/qemu-user-static
+        - PACKAGE_URI="https://kojipkgs.fedoraproject.org/packages/qemu/4.0.0/1.fc31/x86_64/qemu-user-static-4.0.0-1.fc31.x86_64.rpm"
+        - PACKAGE_FILENAME=$(basename "$PACKAGE_URI")
 before_script:
-  - wget --content-disposition $PACKAGE_URI
-  - rpm2cpio $PACKAGE_FILENAME | cpio -dimv
+    - wget --content-disposition $PACKAGE_URI
+    - rpm2cpio $PACKAGE_FILENAME | cpio -dimv
 script:
-  - ./generate_tarballs.sh
-  - |
-    if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then
-        ./publish.sh -v "$VERSION" -t "$GITHUB_TOKEN" -r "$REPO" && \
-            ./update.sh -v "$VERSION" -r "$REPO"
-    fi
+    - ./generate_tarballs.sh
+    - |
+      if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then
+          ./publish.sh -v "$VERSION" -t "$GITHUB_TOKEN" -r "$REPO" && \
+              ./update.sh -v "$VERSION" -r "$REPO"
+      fi
 after_success:
-  - |
-    if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then
-        docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" && \
-            docker push $REPO
-    fi
+    - |
+      if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then
+          docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" && \
+              docker push $REPO
+      fi


### PR DESCRIPTION
### What does this PR do?
Qemu V4 is out y'all! 🎉 Release notes available [here](https://www.qemu.org/2019/04/24/qemu-4-0-0/). This PR simply upgrades to the latest build.

### How was it tested?
I've verified:
- Build passes on Travis: https://travis-ci.org/jessestuart/qemu-user-static/builds/524779982
- Release is created on GH w/ updated binaries, see the release on my fork here: https://github.com/jessestuart/qemu-user-static/releases/tag/v4.0.0
- Successfully used said release to cross-build an aarch64 docker image, (in this case, my [fork of MinIO](https://github.com/jessestuart/minio-multiarch)).
- Pushed the resulting image to my self hosted registry @ `r.j3s.co/minio:latest-qemu4`, and  verified that it runs on one of my arm64 boards:

<img width="1373" alt="Screenshot 2019-04-26 01 57 09" src="https://user-images.githubusercontent.com/583147/56786352-b5099380-67c6-11e9-9c0c-bb441d93e51c.png">

-----------

### Q&A

Am I missing any steps in the release / QA process here, or does this look good to go?