### PR TITLE
Add alpine, fedora and centos to compatible images with GitHub links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,13 @@ Same as above, but remove all registered `binfmt_misc` before
 ## Compatible images
 
 * [hub.docker.com/r/multiarch/](https://hub.docker.com/r/multiarch/)
-  * [ubuntu-core](https://hub.docker.com/r/multiarch/ubuntu-core/)
-  * [debian-debootstrap](https://hub.docker.com/r/multiarch/debian-debootstrap/)
-  * [ubuntu-debootstrap](https://hub.docker.com/r/multiarch/ubuntu-debootstrap/)
-  * [busybox](https://hub.docker.com/r/multiarch/busybox/)
+  * alpine: [Docker Hub](https://hub.docker.com/r/multiarch/alpine/), [GitHub](https://github.com/multiarch/alpine)
+  * debian-debootstrap: [Docker Hub](https://hub.docker.com/r/multiarch/debian-debootstrap/), [GitHub](https://github.com/multiarch/debian-debootstrap)
+  * ubuntu-core: [Docker Hub](https://hub.docker.com/r/multiarch/ubuntu-core/), [GitHub](https://github.com/multiarch/ubuntu-core)
+  * ubuntu-debootstrap: [Docker Hub](https://hub.docker.com/r/multiarch/ubuntu-debootstrap/), [GitHub](https://github.com/multiarch/ubuntu-debootstrap)
+  * fedora: [Docker Hub](https://hub.docker.com/r/multiarch/fedora/), [GitHub](https://github.com/multiarch/fedora)
+  * centos: [Docker Hub](https://hub.docker.com/r/multiarch/centos/), [GitHub](https://github.com/multiarch/centos)
+  * busybox: [Docker Hub](https://hub.docker.com/r/multiarch/busybox/), [GitHub](https://github.com/multiarch/busybox)
 
 Organizations with some (if not all) multiarch images:
 


### PR DESCRIPTION
I like adding alpine, fedora and centos to README's Compatible images section.
Also adding the GitHub links.
Because this repository is a kind of the top page of multiarch project as a reality.
I like to show people the actual GitHub project, as they can find a proper repository to open a ticket or to contribute.

About an order of the images, seeing a number of stars on each GitHub repositories, I think nowadays "alpine" is the most popular. I added it to the top of the list.
It seems that "Docker Hub" is the official name, "GitHub" is the official name.

Here is the modified README.
https://github.com/junaruga/qemu-user-static/blob/feature/readme-images-github/README.md

How do you think?
