### PR TITLE
Add Supported host architectures section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ Same as above, but remove all registered `binfmt_misc` before
 
 ---
 
+## Supported host architectures
+
+* x86_64
+
+Currently qemu-user-static is not available on other host architectures such as aarch64.
+Run `uname -m` to check it on your environment.
+
 ## Examples & articles
 
 * Scaleway's build system:


### PR DESCRIPTION
Shall we add supported host architectures section to README?

It's to explain users explicitly that currently qemu-user-static is available on only x86_64.

This information is helpful for users to notice it by themselves.
They do not have to spend a time to report the issue.

Here is the modified README. You can check it.
https://github.com/junaruga/qemu-user-static/blob/feature/readme-supported-host-archs/README.md

Below are issues about host arch aarch64.
https://github.com/multiarch/qemu-user-static/issues/60
https://github.com/multiarch/qemu-user-static/issues/36
https://github.com/multiarch/qemu-user-static/issues/8
