### PR TITLE
Add ISSUE_TEMPLATE.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,45 @@
+<!--
+Issue report information
+
+* You do NOT have to include this information if this is a feature request.
+-->
+
+**Is this a bug report, feature (enhancement) request or question? (leave only one on its own line)**
+
+/kind bug
+
+/kind enhancement
+
+/kind question
+
+**Description:**
+
+<!--
+Briefly describe the problem you are having in a few paragraphs.
+-->
+
+**Steps to reproduce the issue:**
+
+1.
+
+2.
+
+3.
+
+**Describe the results you received:**
+
+**Describe the results you expected:**
+
+**Environment:**
+
+<!-- The host architecture is available for only x86_64 -->
+* QEMU version: (if you can know it):
+* Container application: Docker/Podman/Singularity (Leave only one)
+
+**Output of `docker version`, `podman version` or `singularity version`**
+
+```
+(paste your output here)
+```
+
+**Additional information optionally:**


### PR DESCRIPTION
This PR fixes https://github.com/multiarch/qemu-user-static/issues/68 .

I created an issue template.
The operation with the template helps for us to know the detail of the issue.

You can see this template at below my repository, clicking "New Issue".
https://github.com/junaruga/qemu-user-static/issues

The content in the template means if it is included in the ticket, the Label is automatically applied.

```
/kind bug

/kind enhancement

/kind question
```

I was mainly inspired from https://github.com/containers/libpod/blob/master/.github/ISSUE_TEMPLATE.md .

This template is old style. But I think it's better for small start comparing the new style template.
