### PR TITLE
Bump version of qemu to 4.0.0-5.fc31

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,11 @@ addons:
             - cpio
 env:
     global:
-        - VERSION=4.0.0-2
+        - VERSION=4.0.0-5
         # See qemu-user-static's RPM spec file on Fedora to check the new version.
         # https://src.fedoraproject.org/rpms/qemu/blob/master/f/qemu.spec
         - REPO=multiarch/qemu-user-static
-        - PACKAGE_URI="https://kojipkgs.fedoraproject.org/packages/qemu/4.0.0/2.fc31/x86_64/qemu-user-static-4.0.0-2.fc31.x86_64.rpm"
+        - PACKAGE_URI="https://kojipkgs.fedoraproject.org/packages/qemu/4.0.0/5.fc31/x86_64/qemu-user-static-4.0.0-5.fc31.x86_64.rpm"
         - PACKAGE_FILENAME=$(basename "$PACKAGE_URI")
 before_script:
     - wget --content-disposition $PACKAGE_URI


### PR DESCRIPTION
Update to Fedora's `4.0.0-5` to include a back-ported fix for PPC.
See https://github.com/conda-forge/docker-images/pull/106#issuecomment-507306401:
> Already fixed upstream in https://github.com/qemu/qemu/commit/2a1224359008e23b051b7b45be4789afa0269f8c which Fedora backported in https://src.fedoraproject.org/rpms/qemu/c/8a7ac9c97e27e83f7fa13d21a5956d6faa76aef5?branch=master#_3.