### PR TITLE
Add a new multiarch/qemu-user-static image.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+*.swp
+*~
+# Ignore generated files
+/containers/latest/qemu-*-static
+/containers/register/Dockerfile
+/containers/register/register.sh
+/containers/x86_64_qemu-*/
 /releases
-*.deb
-archs

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,13 @@ env:
         - VERSION=4.0.0-5
         # See qemu-user-static's RPM spec file on Fedora to check the new version.
         # https://src.fedoraproject.org/rpms/qemu/blob/master/f/qemu.spec
+        - DOCKER_SERVER=docker.io
+        # - DOCKER_SERVER=quay.io
+        # Git repository
         - REPO=multiarch/qemu-user-static
+        # Container repository
+        - DOCKER_REPO=$DOCKER_SERVER/multiarch/qemu-user-static
+        # - DOCKER_REPO=$DOCKER_SERVER/your_username/qemu-user-static
         - PACKAGE_URI="https://kojipkgs.fedoraproject.org/packages/qemu/4.0.0/5.fc31/x86_64/qemu-user-static-4.0.0-5.fc31.x86_64.rpm"
         - PACKAGE_FILENAME=$(basename "$PACKAGE_URI")
 before_script:
@@ -25,12 +31,14 @@ script:
     - ./generate_tarballs.sh
     - |
       if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then
-          ./publish.sh -v "$VERSION" -t "$GITHUB_TOKEN" -r "$REPO" && \
-              ./update.sh -v "$VERSION" -r "$REPO"
+          ./publish.sh -v "$VERSION" -t "$GITHUB_TOKEN" -r "$REPO"
       fi
+    - ./update.sh -v "$VERSION" -r "$REPO" -d "$DOCKER_REPO"
+    - docker images
+    - ./test.sh -d "$DOCKER_REPO"
 after_success:
     - |
       if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then
-          docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" && \
-              docker push $REPO
+          docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" "$DOCKER_SERVER" && \
+              docker push "$DOCKER_REPO"
       fi

--- a/containers/latest/Dockerfile
+++ b/containers/latest/Dockerfile
@@ -3,4 +3,5 @@ ENV QEMU_BIN_DIR=/usr/bin
 ADD ./register.sh /register
 ADD https://raw.githubusercontent.com/qemu/qemu/master/scripts/qemu-binfmt-conf.sh /qemu-binfmt-conf.sh
 RUN chmod +x /qemu-binfmt-conf.sh
+COPY qemu-*-static /usr/bin/
 ENTRYPOINT ["/register"]

--- a/containers/latest/register.sh
+++ b/containers/latest/register.sh
@@ -20,4 +20,4 @@ if [ "${1}" = "--reset" ]; then
     find /proc/sys/fs/binfmt_misc -type f -name 'qemu-*' -exec sh -c 'echo -1 > {}' \;
 fi
 
-exec /qemu-binfmt-conf.sh --qemu-suffix "-static" --qemu-path="${QEMU_BIN_DIR}" $@
+exec /qemu-binfmt-conf.sh --qemu-suffix "-static" --qemu-path "${QEMU_BIN_DIR}" $@

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+set -xeo pipefail
+
+# A POSIX variable
+OPTIND=1 # Reset in case getopts has been used previously in the shell.
+
+while getopts "d:" opt; do
+    case "$opt" in
+        d)  DOCKER_REPO=$OPTARG
+        ;;
+    esac
+done
+
+if [ "${DOCKER_REPO}" = "" ]; then
+    echo "DOCKER_REPO is required." 1>&2
+    exit 1
+fi
+
+# Test cases
+
+# ------------------------------------------------
+# multiarch/qemu-user-static image
+
+# It should register binfmt_misc entry with 'flags: F'
+# by given "-p yes" option.
+sudo docker run --rm --privileged ${DOCKER_REPO} --reset -p yes
+cat /proc/sys/fs/binfmt_misc/qemu-aarch64
+grep -q '^flags: F$' /proc/sys/fs/binfmt_misc/qemu-aarch64
+
+# It should output the result of "uname -m".
+docker pull arm64v8/ubuntu
+docker run --rm -t arm64v8/ubuntu uname -m
+# It should install a package.
+docker build --rm -t "test/latest/ubuntu" -<<EOF
+FROM arm64v8/ubuntu
+RUN apt-get update && \
+    apt-get -y install gcc
+EOF
+
+# It should output the result of "uname -m".
+docker pull arm64v8/fedora
+docker run --rm -t arm64v8/fedora uname -m
+# It should install a package.
+# TODO: Comment out as it takes a time.
+# docker build --rm -t "test/latest/fedora" -<<EOF
+# FROM arm64v8/fedora
+# RUN dnf -y upgrade && \
+#     dnf -y install gcc
+# EOF
+
+# ------------------------------------------------
+# multiarch/qemu-user-static:register image
+
+# It should register binfmt_misc entry with 'flags: '
+# by given no "-p yes" option.
+sudo docker run --rm --privileged ${DOCKER_REPO}:register --reset
+cat /proc/sys/fs/binfmt_misc/qemu-aarch64
+grep -q '^flags: $' /proc/sys/fs/binfmt_misc/qemu-aarch64
+
+# ------------------------------------------------
+# multiarch/qemu-user-static:$to_arch image
+# multiarch/qemu-user-static:$from_arch-$to_arch image
+
+# /usr/bin/qemu-aarch64-static should be included.
+docker run --rm -t ${DOCKER_REPO}:aarch64 /usr/bin/qemu-aarch64-static --version
+docker run --rm -t ${DOCKER_REPO}:x86_64-aarch64 /usr/bin/qemu-aarch64-static --version
+
+# ------------------------------------------------
+# Integration test
+docker build --rm -t "test/integration/ubuntu" -<<EOF
+FROM ${DOCKER_REPO}:x86_64-aarch64 as qemu
+FROM arm64v8/ubuntu
+COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin
+EOF
+docker run --rm -t "test/integration/ubuntu" uname -m

--- a/update.sh
+++ b/update.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
-set -e
+set -xe
 
 # A POSIX variable
 OPTIND=1 # Reset in case getopts has been used previously in the shell.
 
-while getopts "r:v:" opt; do
+while getopts "r:v:d:" opt; do
     case "$opt" in
         r)  REPO=$OPTARG
         ;;
         v)  VERSION=$OPTARG
+        ;;
+        d)  DOCKER_REPO=$OPTARG
         ;;
     esac
 done
@@ -25,20 +27,42 @@ shift $((OPTIND-1))
 
 from_arch="x86_64"
 to_archs="aarch64 aarch64_be alpha armeb arm cris hppa i386 m68k microblazeel microblaze mips64el mips64 mipsel mipsn32el mipsn32 mips nios2 or1k ppc64abi32 ppc64le ppc64 ppc riscv32 riscv64 s390x sh4eb sh4 sparc32plus sparc64 sparc tilegx trace-stap x86_64 xtensaeb xtensa"
+# For casual test
+# to_archs="aarch64"
+
+# Build container images creating the directory.
+# containers/
+#   latest/ - An image including /usr/bin/qemu-$arch-status and /register script.
+#   ${from_arch}_qemu-${to_arch}/ - Images including /usr/bin/qemu-$arch-status
+#   register/ - An image including /register script.
+out_dir="containers"
+
+# Generate register files.
+cp -p "${out_dir}/latest/register.sh" "${out_dir}/register/"
+cp -p "${out_dir}/latest/Dockerfile" "${out_dir}/register/"
+# Comment out the line to copy qemu-*-static not to provide those.
+sed -i '/^COPY qemu/ s/^/#/' "${out_dir}/register/Dockerfile"
 
 for to_arch in $to_archs; do
     if [ "$from_arch" != "$to_arch" ]; then
-        mkdir -p ${from_arch}_qemu-${to_arch}
-        curl -sSL -o "${from_arch}_qemu-${to_arch}/${from_arch}_qemu-${to_arch}-static.tar.gz" \
+        work_dir="${out_dir}/${from_arch}_qemu-${to_arch}"
+        mkdir -p "${work_dir}"
+        curl -sSL -o "${work_dir}/${from_arch}_qemu-${to_arch}-static.tar.gz" \
             "https://github.com/${REPO}/releases/download/v${VERSION}/${from_arch}_qemu-${to_arch}-static.tar.gz"
-        cat > ${from_arch}_qemu-${to_arch}/Dockerfile -<<EOF
+        tar xzvf "${work_dir}/${from_arch}_qemu-${to_arch}-static.tar.gz" -C "${work_dir}"
+        rm -f "${work_dir}/${from_arch}_qemu-${to_arch}-static.tar.gz"
+
+        cp -p "${work_dir}/qemu-${to_arch}-static" "${out_dir}/latest/"
+
+        cat > ${work_dir}/Dockerfile -<<EOF
 FROM scratch
-ADD ${from_arch}_qemu-${to_arch}-static.tar.gz /usr/bin/
+COPY qemu-${to_arch}-static /usr/bin/
 EOF
-        docker build -t ${REPO}:$from_arch-$to_arch ${from_arch}_qemu-${to_arch}
-        docker tag ${REPO}:$from_arch-$to_arch ${REPO}:$to_arch
-        rm -rf ${from_arch}_qemu-${to_arch}
+        docker build -t ${DOCKER_REPO}:$from_arch-$to_arch ${work_dir}
+        docker tag ${DOCKER_REPO}:$from_arch-$to_arch ${DOCKER_REPO}:$to_arch
+        rm -rf "${work_dir}"
     fi
 done
 
-docker build -t ${REPO}:register register
+docker build -t ${DOCKER_REPO}:latest "${out_dir}/latest"
+docker build -t ${DOCKER_REPO}:register "${out_dir}/register"


### PR DESCRIPTION
This PR is related to https://github.com/multiarch/qemu-user-static/issues/37#issuecomment-514312926 .

I implemented below features. Thank you https://github.com/dbhi/qus project, that inspired us!

> * Check/ensure that ADD does extract the tarball and not only copy it: 
> * Add all the binaries in multiarch/qemu-user-static:* images to image multiarch/qemu-user-static:register.

That includes both the register script file and qemu-$arch-static binary files.
Because when we want to run the register script (qemu-binfmt-conf.sh)
with "--persistent" option, to register the binary format entries with "flags: F",
the interpreters "/usr/bin/qemu-$arch-static" need to be existed.

See https://www.kernel.org/doc/html/latest/admin-guide/binfmt-misc.html

Other notable changes
* Modify to save files on containers directory for container images.
* test.sh for CI gating test.

## The result of my tests

* Here is my container repository used for testing: https://quay.io/repository/junaruga/qemu-user-static
* Here is the result of Travis CI on my repository: https://travis-ci.org/junaruga/qemu-user-static/builds/564534755
* Here is my forked repository's pull-request branch: https://github.com/junaruga/qemu-user-static/tree/feature/unified-image . You can see new directory `containers/`.
* You can run the testing script `./test.sh -d "quay.io/junaruga/qemu-user-static"` on your local. The testing script is also added on CI.

I tested like this.

```
$ git diff
diff --git a/.travis.yml b/.travis.yml
index 79ca070..edee35e 100644
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,13 @@ env:
         - VERSION=4.0.0-5
         # See qemu-user-static's RPM spec file on Fedora to check the new version.
         # https://src.fedoraproject.org/rpms/qemu/blob/master/f/qemu.spec
-        - DOCKER_SERVER=docker.io
-        # - DOCKER_SERVER=quay.io
+        # - DOCKER_SERVER=docker.io
+        - DOCKER_SERVER=quay.io
         # Git repository
         - REPO=multiarch/qemu-user-static
         # Container repository
-        - DOCKER_REPO=$DOCKER_SERVER/multiarch/qemu-user-static
-        # - DOCKER_REPO=$DOCKER_SERVER/your_username/qemu-user-static
+        # - DOCKER_REPO=$DOCKER_SERVER/multiarch/qemu-user-static
+        - DOCKER_REPO=$DOCKER_SERVER/junaruga/qemu-user-static
 
         - PACKAGE_URI="https://kojipkgs.fedoraproject.org/packages/qemu/4.0.0/5.fc31/x86_64/qemu-user-static-4.0.0-5.fc31.x86_64.rpm"
         - PACKAGE_FILENAME=$(basename "$PACKAGE_URI")
@@ -39,7 +39,7 @@ script:
     - ./test.sh -d "$DOCKER_REPO"
 after_success:
     - |
-      if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then
+      # if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then
           docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" "$DOCKER_SERVER" && \
               docker push "$DOCKER_REPO"
-      fi
+      # fi
```

## Deprecate the concept of 'Compatible images'

After this PR will be merged, we can build and run standard multiarch images without using the multiarch compatible images.

```
$ sudo docker run --rm --privileged quay.io/junaruga/qemu-user-static --reset -p yes

$ docker run --rm -t arm64v8/ubuntu uname -m
aarch64

$ docker run --rm -t arm64v8/fedora uname -m
aarch64
```
