### PR TITLE
[ci skip] Update documents considering new features.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# How to contribute to multiarch/qemu-user-static
+# Contributing to multiarch/qemu-user-static
 
 Your contributions such as reporting a bug and sending pull-request are very wellcome! Thank you.
 

--- a/docs/compatible_images.md
+++ b/docs/compatible_images.md
@@ -1,0 +1,16 @@
+# Compatible images [DEPRECATED]
+
+* [hub.docker.com/r/multiarch/](https://hub.docker.com/r/multiarch/)
+  * alpine: [Docker Hub](https://hub.docker.com/r/multiarch/alpine/), [GitHub](https://github.com/multiarch/alpine)
+  * debian-debootstrap: [Docker Hub](https://hub.docker.com/r/multiarch/debian-debootstrap/), [GitHub](https://github.com/multiarch/debian-debootstrap)
+  * ubuntu-core: [Docker Hub](https://hub.docker.com/r/multiarch/ubuntu-core/), [GitHub](https://github.com/multiarch/ubuntu-core)
+  * ubuntu-debootstrap: [Docker Hub](https://hub.docker.com/r/multiarch/ubuntu-debootstrap/), [GitHub](https://github.com/multiarch/ubuntu-debootstrap)
+  * fedora: [Docker Hub](https://hub.docker.com/r/multiarch/fedora/), [GitHub](https://github.com/multiarch/fedora)
+  * centos: [Docker Hub](https://hub.docker.com/r/multiarch/centos/), [GitHub](https://github.com/multiarch/centos)
+  * busybox: [Docker Hub](https://hub.docker.com/r/multiarch/busybox/), [GitHub](https://github.com/multiarch/busybox)
+
+Organizations with some (if not all) multiarch images:
+
+* [hub.docker.com/u/multiarch](https://hub.docker.com/u/multiarch/)
+* [hub.docker.com/u/scaleway](https://hub.docker.com/u/scaleway/)
+* [hub.docker.com/u/meyskens](https://hub.docker.com/u/meyskens/)

--- a/docs/developers_guide.md
+++ b/docs/developers_guide.md
@@ -1,0 +1,107 @@
+# Developers guide
+
+We provide information to understand this system in this document.
+
+## Technology overview
+
+### qemu-user-static
+
+qemu-user-static is a collection of `qemu-$arch-static` "static" binary files that emulates application process (QEMU "user" mode) and binfmt_misc related files. [1]
+In this system, Fedora project's qemu-user-static RPM is used as the input data. qemu-user-static RPM is sub package of qemu RPM. [2]
+
+`qemu-$arch-static` file is just an interpreter to run the archtecture specfic binary. Below is an example to run aarch64 specifc binary `bin/hello-aarch64` on `qemu-aarch64-static`.
+
+```
+$ uname -m
+x86_64
+
+$ file bin/hello-aarch64
+bin/hello-aarch64: ELF 64-bit LSB executable, ARM aarch64, version 1 (GNU/Linux), statically linked, BuildID[sha1]=fa19c63e3c60463e686564eeeb0937959bd6f559, for GNU/Linux 3.7.0, not stripped, too many notes (256)
+
+$ bin/hello-aarch64
+bash: bin/hello-aarch64: cannot execute binary file: Exec format error
+
+$ qemu-aarch64-static bin/hello-aarch64
+Hello World!
+```
+
+`qemu-$cpu-static` can run the architecture specific binary.
+
+
+### qemu-user-static and binfmt_misc
+
+qemu-user-static becomes powerful when it is used with binfmt_misc [3].
+If you are interested in the C language level manual, see [4].
+
+Here is an example of the most typical and recommended way to run different architecture's container.
+In this example, aarch64 (ARM 64-bit) container are executed on host architecture x86_64.
+The example shows what the container image is doing.
+
+```
+$ uname -m
+x86_64
+
+$ ls /proc/sys/fs/binfmt_misc/qemu-aarch64
+ls: cannot access '/proc/sys/fs/binfmt_misc/qemu-aarch64': No such file or directory
+
+$ docker run --rm -t arm64v8/ubuntu uname -m
+standard_init_linux.go:211: exec user process caused "exec format error"
+
+$ docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
+$ ls /proc/sys/fs/binfmt_misc/qemu-aarch64
+/proc/sys/fs/binfmt_misc/qemu-aarch64
+
+$ cat /proc/sys/fs/binfmt_misc/qemu-aarch64
+enabled
+interpreter /usr/bin/qemu-aarch64-static
+flags: F
+offset 0
+magic 7f454c460201010000000000000000000200b700
+mask ffffffffffffff00fffffffffffffffffeffffff
+
+$ docker run --rm -t arm64v8/ubuntu uname -m
+aarch64
+```
+
+In this system, understanding the difference of the behavior of 2 patterns of flags: `flags: ` (empty flag) and `flags: F` is important.
+According to [3], the actual operation and behavior are as follows.
+
+* `# echo ":$name:$type:$offset:$magic:$mask:$interpreter:$flags" > /proc/sys/fs/binfmt_misc/register` to add a binary format entry.
+* `# echo -1 > /proc/sys/fs/binfmt_misc/qemu-$arch` to remove a qemu binary format entry.
+* If the entry file's `flags` is empty, the exsistance of the interpreter is checked at run time.
+* If the entry file's `flags` is `flags: F`, the existance of the interpreter is checked when registering the entry.
+
+### qemu-user-static, binfmt_misc and container
+
+A point to keep in mind when using qemu-user-static and binfmt_misc in container, is binfmt_misc `/proc/sys/fs/binfmt_misc` files `register`, `status` and `qemu-$arch` are shared and commonly used between host and inside of container. As a result, a script executed in container can modify `/proc/sys/fs/binfmt_misc` files on host OS.
+binfmt_misc is a feature of kernel. A container uses the host OS's kernel.
+
+## Programs input & output
+
+In this section, we describe a program's input and output.
+This repository is a pipeline system by using Travis CI.
+
+First, we describe the entire pipelne system's input and output. `.travis.yml` is the top level file.
+
+* Input of the pipeline: `qemu-user-static-X.Y.Z-R.fcNN.$arch.rpm` RPM file under [Fedora Project URL](https://kojipkgs.fedoraproject.org/packages/qemu). Right now `$arch` is only x86_64.
+* Output of the pipeline:
+  * [GitHub Releases page](https://github.com/multiarch/qemu-user-static/releases): `qemu-$arch-static` binary files, `qemu-$arch-static.tar.gz` and `x86_64_qemu-$arch-static.tar.gz` (`$from_arch_qemu-$arch-statc.tar.gz`). `qemu-$arch-static.tar.gz` files are same content with `x86_64_qemu-$arch-static.tar.gz`. It is an implementation to add supported host architectures `$from_arch` in the future.
+  * Images on [Docker Hub](https://hub.docker.com/r/multiarch/qemu-user-static/). For actual images, see `README.md` Usage - multiarch/qemu-user-static images section.
+
+Second, we describe each program's input and output by sequence.
+
+| Step | Name | Description | Input | Output |
+| ---- | ---- | ----------- | ----- | ------ |
+| 1 | `generate_tarballs.sh` | Create tar.gz files to upload GitHub Releases page. | `qemu-$arch-static` files in qemu-user-static RPM  | `qemu-$arch-static.tar.gz` and `x86_64_qemu-$arch-static.tar.gz` files |
+| 2 | `publish.sh` | Upload the tar.gz files by [GitHub API](https://developer.github.com/) | `qemu-$arch-static.tar.gz` and `x86_64_qemu-$arch-static.tar.gz` files | `qemu-$arch-static.tar.gz` and `x86_64_qemu-$arch-static.tar.gz` files on GitHub Releases page. |
+| 3 | `update.sh` | Create container images on local | `x86_64_qemu-$arch-static.tar.gz` files on GitHub Releases page. | Container images on local |
+| 4 | `test.sh` | Test created container images on local | Container images on local | `test/*` container images created as a result of tests  |
+| 5 | `docker push $DOCKER_REPO` | Push the container images to DockerHub | `multiarch/qemu-user-static:*` container images on local | `multiarch/qemu-user-static:*` container images on Docker Hub |
+
+## References
+
+* [1] QEMU: https://www.qemu.org/
+* [2] Fedora qemu RPM: https://src.fedoraproject.org/rpms/qemu
+* [3] binfmt_misc: https://www.kernel.org/doc/html/latest/admin-guide/binfmt-misc.html
+* [4] binfmt_misc C language level manual: https://lwn.net/Articles/630727/

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,19 @@
+# Sister projects, examples & articles
+
+## Sister projects
+
+* [qemu-user-static (qus) and docker](https://github.com/dbhi/qus)
+
+## Examples and articles [DEPRECATED]?
+
+* Scaleway's build system:
+  * [scaleway/image-tools](https://github.com/scaleway/image-tools)
+  * [scaleway/image-builder](https://github.com/scaleway/image-builder)
+* [Docker + multiarch = <3](https://manfredtouron.com/2016/01/28/docker-multiarch/) (Release blog post)
+* Introduction article: [eyskens.me/multiarch-docker-images](https://eyskens.me/multiarch-docker-images/)
+* Dockerized C benchmarks for both ARM and amd64 hardware: [luxas/benchmark](https://github.com/luxas/benchmark)
+* Standalone image example: [meyskens/multiarch-nodejs](https://github.com/meyskens/multiarch-nodejs)
+* RaspberryPI + haskell hacks:
+  * [TGOlson/rpi-haskell](https://github.com/TGOlson/rpi-haskell)
+  * [TGOlson/rpi-haskell-classy](https://github.com/TGOlson/rpi-haskell-classy)
+* Music notation software: [musescore/MuseScore](https://github.com/musescore/MuseScore)


### PR DESCRIPTION
This PR is for https://github.com/multiarch/qemu-user-static/issues/37#issuecomment-515738343 below remaining 2 tasks.
I updated the documents. The updated or added flies are only document files.

> Deprecate the concept of 'Compatible images' and remove the section from the README. : not yet

I moved the 'Compatible images' from `README.md` to `docs/compatible_images.md` adding the title `[DEPRECATED]`. The new page is linked from `README.md`.

> Deprecate the 'Examples & articles' section of the README and provide some up-to-date article that enforces using -p. : not yet

I moved the 'Compatible images' from `README.md` to `docs/examples.md` adding the title `[DEPRECATED]?`. The new page is linked from `README.md`. Maybe we can remove some of the examples or archites. But I want to ask people who added the articles.

Here are lines related to "DEPRECATED".

```
$ grep -rin DEPRECATED *.md docs/
README.md:186:### multiarch compatible images [DEPRECATED]
README.md:188:The concept of "compatible images" are deprecated because **multiarch/qemu-user-static** can build and run standard multi-architecture container images without the multiarch compatible images now. But you can refer the document [Compatible images](docs/compatible_images.md).
README.md:211:Please note that some examples using compatible images are deprecated.
docs/compatible_images.md:1:# Compatible images [DEPRECATED]
docs/examples.md:7:## Examples and articles [DEPRECATED]?
```

Update documents considering new features.
The modified files are here.
https://github.com/junaruga/qemu-user-static/tree/feature/update-docs

Modified or added files

* [CONTRIBUTING.md](https://github.com/junaruga/qemu-user-static/blob/feature/update-docs/CONTRIBUTING.md)
  * Change the title.
* [README.md](https://github.com/junaruga/qemu-user-static/blob/feature/update-docs/README.md)
  * Change logo image format from HTML markup style to markdown style aligning with other "multiarch/*" repositories.
  * I wrote the use case to use standard container image with the command `docker run --rm --privileged multiarch/qemu-user-static --reset -p yes` command in the top area. Because I think the command becomes the most useful and often used. It is better that we promote the command.
* [docs/compatible_images.md](https://github.com/junaruga/qemu-user-static/blob/feature/update-docs/docs/compatible_images.md)
  * New page moved from `README.md`.
* [docs/developers_guide.md](https://github.com/junaruga/qemu-user-static/blob/feature/update-docs/docs/developers_guide.md)
  * New page that is useful for people who want to understand how this repository works. I think adding developer's document promotes contribution to this repository.
* [docs/examples.md](https://github.com/junaruga/qemu-user-static/blob/feature/update-docs/docs/examples.md)
  * New page moved from `README.md`.
  * I added "Sister projects" section with https://github.com/dbhi/qus .

Could you review this pull-request? Thank you.