### PR TITLE
[ci skip] Add an i386 example to the document.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ $ docker run --rm -t ppc64le/busybox uname -m
 ppc64le
 ```
 
+For 32-bit container image, the result of `uname` can be the 64-bit's one. But it is 32-bit environment. Please see the [example](docs/examples.md) - junaruga/ci-multi-arch-test i386 case on Travis CI.
+
+```
+$ docker run --rm -t i386/ubuntu uname -m
+x86_64
+```
+
 Podman [4] also works.
 
 ```

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -4,6 +4,10 @@
 
 * [qemu-user-static (qus) and docker](https://github.com/dbhi/qus)
 
+## Examples and articles
+
+* [junaruga/ci-multi-arch-test](https://github.com/junaruga/ci-multi-arch-test) and the [Travis CI](https://travis-ci.org/junaruga/ci-multi-arch-test)
+
 ## Examples and articles [DEPRECATED]?
 
 * Scaleway's build system:


### PR DESCRIPTION
Related to this question: https://github.com/multiarch/qemu-user-static/issues/81 .
Shall we add an example about i386 to the document?

I like to add my repository https://github.com/junaruga/ci-multi-arch-test that is used to investigate multi-arch tech and CI to the examples.

Modified documents.

https://github.com/junaruga/qemu-user-static/tree/feature/doc-i386

* [README.md](https://github.com/junaruga/qemu-user-static/blob/feature/doc-i386/README.md)
* [docs/examples.md](https://github.com/junaruga/qemu-user-static/blob/feature/doc-i386/docs/examples.md)
