### PR TITLE
Implement tag versioning.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,14 @@ addons:
             - cpio
 env:
     global:
-        - VERSION=4.0.0-5
+        - MAJOR_VERSION=4
+        - MINOR_VERSION=0
+        - PATCH_VERSION=0
+        - RELEASE_VERSION=5
+        - VERSION=$MAJOR_VERSION.$MINOR_VERSION.$PATCH_VERSION-$RELEASE_VERSION
+        # Container tag version string.
+        # Set it here to give a flexibility of the value such as "vX.Y".
+        - TAG_VER=v$VERSION
         # See qemu-user-static's RPM spec file on Fedora to check the new version.
         # https://src.fedoraproject.org/rpms/qemu/blob/master/f/qemu.spec
         - DOCKER_SERVER=docker.io
@@ -33,7 +40,7 @@ script:
       if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then
           ./publish.sh -v "$VERSION" -t "$GITHUB_TOKEN" -r "$REPO"
       fi
-    - ./update.sh -v "$VERSION" -r "$REPO" -d "$DOCKER_REPO"
+    - ./update.sh -v "$VERSION" -t "$TAG_VER" -r "$REPO" -d "$DOCKER_REPO"
     - docker images
     - ./test.sh -d "$DOCKER_REPO"
 after_success:


### PR DESCRIPTION
Sorry, related to the PR: https://github.com/multiarch/qemu-user-static/pull/83 and https://github.com/multiarch/qemu-user-static/issues/74 , let me fix the versioning with minimal steps.

Because I think @meeDamian and #74 's reporter want to see the versioning will be implemented with high priority soon. Other features on #83 are not urgent for them.

## Testing

Here is my Travis's result.
You see the containers are created with version tag.
https://travis-ci.org/junaruga/qemu-user-static/builds/572536735#L2217

```
$ docker images
REPOSITORY                   TAG                        IMAGE ID            CREATED              SIZE
multiarch/qemu-user-static   latest                     b5cb43048545        1 second ago         133MB
multiarch/qemu-user-static   v4.0                       b5cb43048545        1 second ago         133MB
multiarch/qemu-user-static   register                   1597e2d87f47        1 second ago         1.25MB
multiarch/qemu-user-static   register-v4.0              1597e2d87f47        1 second ago         1.25MB
multiarch/qemu-user-static   x86_64-xtensa              19f490eb93c7        10 seconds ago       4.65MB
multiarch/qemu-user-static   x86_64-xtensa-v4.0         19f490eb93c7        10 seconds ago       4.65MB
multiarch/qemu-user-static   xtensa                     19f490eb93c7        10 seconds ago       4.65MB
multiarch/qemu-user-static   xtensa-v4.0                19f490eb93c7        10 seconds ago       4.65MB
...
```

Here is my testing container repository.
https://quay.io/repository/junaruga/qemu-user-static?tab=tags

I also tested new version tag.

```
$ docker run --rm --privileged quay.io/junaruga/qemu-user-static --reset -p yes
$ docker run --rm --privileged quay.io/junaruga/qemu-user-static:v4.0 --reset -p yes

$ cat /proc/sys/fs/binfmt_misc/qemu-aarch64
...
flags: F
...

$ docker run --rm --privileged quay.io/junaruga/qemu-user-static:register --reset
$ docker run --rm --privileged quay.io/junaruga/qemu-user-static:register-v4.0 --reset

$ cat /proc/sys/fs/binfmt_misc/qemu-aarch64
...
flags:
...

$ docker run --rm -t quay.io/junaruga/qemu-user-static:x86_64-aarch64 /usr/bin/qemu-aarch64-static -version
$ docker run --rm -t quay.io/junaruga/qemu-user-static:x86_64-aarch64-v4.0 /usr/bin/qemu-aarch64-static -version
```


After merging this PR, I want to run with `VERSION: v3.1.0-3` to create the "v3.1" containers.
Then run it with `v.4.0.0-5 ` again.

I think it is good enough to fix #74 .
