### PR TITLE
Remove aarch trace-stap in update.sh.

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -28,7 +28,7 @@ shift $((OPTIND-1))
 [ "$1" = "--" ] && shift
 
 from_arch="x86_64"
-to_archs="aarch64 aarch64_be alpha armeb arm cris hppa i386 m68k microblazeel microblaze mips64el mips64 mipsel mipsn32el mipsn32 mips nios2 or1k ppc64abi32 ppc64le ppc64 ppc riscv32 riscv64 s390x sh4eb sh4 sparc32plus sparc64 sparc tilegx trace-stap x86_64 xtensaeb xtensa"
+to_archs="aarch64 aarch64_be alpha armeb arm cris hppa i386 m68k microblazeel microblaze mips64el mips64 mipsel mipsn32el mipsn32 mips nios2 or1k ppc64abi32 ppc64le ppc64 ppc riscv32 riscv64 s390x sh4eb sh4 sparc32plus sparc64 sparc tilegx x86_64 xtensaeb xtensa"
 # For casual test
 # to_archs="aarch64"
 


### PR DESCRIPTION
qemu-trace-stap-static is not included in qemu-user-static-3.1.1-2.fc30.x86_64.rpm .

Related to https://github.com/multiarch/qemu-user-static/pull/85#issuecomment-522005861 .