### PR TITLE
Change version tag "vX.Y.Z-R" to "X.Y.Z-R".

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ env:
         - RELEASE_VERSION=5
         - VERSION=$MAJOR_VERSION.$MINOR_VERSION.$PATCH_VERSION-$RELEASE_VERSION
         # Container tag version string.
-        # Set it here to give a flexibility of the value such as "vX.Y".
-        - TAG_VER=v$VERSION
+        # Set it here to give a flexibility of the value such as "X.Y".
+        - TAG_VER=$VERSION
         # See qemu-user-static's RPM spec file on Fedora to check the new version.
         # https://src.fedoraproject.org/rpms/qemu/blob/master/f/qemu.spec
         - DOCKER_SERVER=docker.io


### PR DESCRIPTION
To align a general container's version tag rule on DockerHub and etc.

This fixes https://github.com/multiarch/qemu-user-static/issues/91 .

After this PR is merged, I will run the pipeline for qemu "3.1.1-2", "4.0.0-4", "4.0.0-5" (again) and the latest version "4.1.0-1".
https://src.fedoraproject.org/rpms/qemu/blob/master/f/qemu.spec

The created images look good.

https://travis-ci.org/multiarch/qemu-user-static/builds/579575711#L1306

```
$ docker images
REPOSITORY                   TAG                           IMAGE ID            CREATED                  SIZE
multiarch/qemu-user-static   register                      d8cfc7ba0dab        Less than a second ago   1.25MB
multiarch/qemu-user-static   4.0.0-5                       201fb779d319        1 second ago             133MB
multiarch/qemu-user-static   latest                        201fb779d319        1 second ago             133MB
multiarch/qemu-user-static   x86_64-xtensa                 4bda0d5739f9        11 seconds ago           4.65MB
multiarch/qemu-user-static   x86_64-xtensa-4.0.0-5         4bda0d5739f9        11 seconds ago           4.65MB
multiarch/qemu-user-static   xtensa                        4bda0d5739f9        11 seconds ago           4.65MB
multiarch/qemu-user-static   xtensa-4.0.0-5                4bda0d5739f9        11 seconds ago           4.65MB
...
```