### PR TITLE
[ci skip] Update README singularity example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,14 +60,12 @@ $ podman run --rm -t arm64v8/fedora uname -m
 aarch64
 ```
 
-Singularity [5] also works. But I do not understand the warnings.
+Singularity [5] also works.
 
 ```
 $ sudo singularity run docker://multiarch/qemu-user-static --reset -p yes
 
-$ singularity run docker://arm64v8/fedora uname -m
-/bin/sh: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
-/bin/sh: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
+$ singularity run --cleanenv docker://arm64v8/fedora uname -m
 aarch64
 ```
 


### PR DESCRIPTION
Add `--cleanenv` option to suppress a warning in the example.
Because Singularity imports all environment variables on host by default
unlike Docker and Podman.

I leaned it from this ticket. :)
https://bugzilla.redhat.com/show_bug.cgi?id=1757168#c1

Updated README is here.
https://github.com/junaruga/qemu-user-static/blob/feature/doc-readme-singularity/README.md