### PR TITLE
Update QEMU to version 8.0.0-4

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -18,8 +18,8 @@ jobs:
   qemu-user-static:
     runs-on: ubuntu-latest
     env:
-      VERSION: 7.2.0-1
-      ORIGIN_VERSION: 7.2+dfsg-1~bpo11+2
+      VERSION: 8.0.0-4
+      ORIGIN_VERSION: 8.0+dfsg-4
     steps:
       - uses: actions/checkout@v2
       - name: Set variables


### PR DESCRIPTION
QEMU 8 has been [released](https://wiki.qemu.org/ChangeLog/8.0) and Debian builds are already available.
Add QEMU 8 support to qemu-user-static.

My test builds are available here: https://hub.docker.com/repository/docker/iiilinuxibmcom/qemu-user-static